### PR TITLE
Fix/gemfile style errors

### DIFF
--- a/lib/gem_sort/sorter.rb
+++ b/lib/gem_sort/sorter.rb
@@ -98,12 +98,18 @@ module GemSort
         wrap_block(source_block, inside)
       }
 
-      source_line = extract_line!(gemfile, -> (line) {
-        line.start_with?('source') && !line.end_with?('do')
+      git_source_blocks = extract_line!(gemfile, -> (line) {
+        line.start_with?('git_source') && !line.include?('do')
       })
 
-      git_source_line = extract_line!(gemfile, -> (line) {
-        line.start_with?('git_source')
+      git_source_blocks = extract_blocks!(gemfile, -> (line) {
+        line.start_with?("git_source")
+      }).map{ |group_block|
+        sort_block_gems(group_block)
+      } if git_source_blocks.nil?
+
+      source_line = extract_line!(gemfile, -> (line) {
+        line.start_with?('source') && !line.end_with?('do')
       })
 
       ruby_line = extract_line!(gemfile, -> (line) {
@@ -115,7 +121,7 @@ module GemSort
       })
 
       sorted_text = inject_between([
-        [source_line, git_source_line],
+        [source_line, git_source_blocks],
         [ruby_line, rails_line],
         sort_gems(gemfile),
         inject_between(group_blocks, nil),


### PR DESCRIPTION
gem_sortが正常に動作しないケースや現状だと見づらいことがあったので修正しました（日本語で恐縮ですが確認お願いします）。
以下このPRで加えた変更
- Rails5から導入されたgit_sourceを正常にソートできるようにした
  - #{repo}という文字列が入り以前の#がつくものを丸ごとカットするロジックだとバグってしまう
  - そこで#の後に{が続いた場合は消さないための正規表現に変更

- gem "~"のようにダブルクオーテーションを用いた場合、正常にソートされなかったのでソートする前に、ダブルクオーテーションをシングルクオーテーションに置き換えるようにした

- gem 'rails',         '~> 5.2.0'のようにgem名とバージョン指定の間に空白が空いている場合に、その間を半角の空白一つに統一するようにした

- 現状空行がなく見づらい状態だったのでブロックごとに空行を入れるようにして見やすくした

- r+モードでGemfileを最終的に書き換えると、上書きした部分より元のGemfileが長かった場合、それが残ってしまうというバグが発生していたので、最後はwモードで元のGemfileの内容をリセットしsort後のGemfileを入力するようにした